### PR TITLE
Use pref to enable/disable use of buffered http requests.

### DIFF
--- a/Changelog8.html
+++ b/Changelog8.html
@@ -9,6 +9,7 @@
 		<li><a href="https://github.com/Logitech/slimserver/pull/537">#537</a> - Add audio option to combine channels to build a mono signal (whether player is synchronized or not).</li>
 		<li><a href="https://github.com/Logitech/slimserver/pull/538">#538</a> - Add Balance setting for players which support it (thanks philippe44!).</li>
 		<li>Enable basic track statistics (play count, last played, ratings) for online tracks imported into the library.</li>
+		<li><a href="https://github.com/Logitech/slimserver/pull/581">#581</a> - Create new player protocol to buffer http streams to disk to improve reliability (thanks philippe44!).</li>
 	</ul>
 	<br />
 

--- a/HTML/EN/settings/server/performance.html
+++ b/HTML/EN/settings/server/performance.html
@@ -67,6 +67,15 @@
 		</select>
 	[% END %]
 
+	[% WRAPPER setting title="SETUP_BUFFEREDHTTP" desc="SETUP_BUFFEREDHTTP_DESC" %]
+		<select class="stdedit" name="pref_useBufferedHTTP" id="useBufferedHTTP">
+
+			<option [% IF NOT prefs.pref_useBufferedHTTP %]selected [% END %]value="0">[% 'SETUP_DISABLE_BUFFEREDHTTP' | getstring %]</option>
+			<option [% IF prefs.pref_useBufferedHTTP %]selected [% END %]value="1">[% 'SETUP_ENABLE_BUFFEREDHTTP' | getstring %]</option>
+
+		</select>
+	[% END %]
+
 	[% IF prioritySettings; WRAPPER settingSection %]
 		[% WRAPPER settingGroup title="SETUP_SERVERPRIORITY" desc="SETUP_SERVERPRIORITY_DESC" %]
 			<select class="stdedit" name="pref_serverPriority" id="serverPriority">

--- a/Slim/Player/Protocols/Buffered.pm
+++ b/Slim/Player/Protocols/Buffered.pm
@@ -18,23 +18,24 @@ sub new {
 	my $class  = shift;
 	my ($args) = @_;
 
-	main::INFOLOG && $log->info("Using Buffered HTTP(S) service for $args->{url}");
 	my $self = $class->SUPER::new(@_) or do {
 		$log->error("Couldn't create socket for Buffered - $!");
 		return undef;
 	};
-	
+
 	# don't buffer if we don't have content-length
 	return $self unless ${*$self}{'contentLength'};
 
-	# HTTP headers have now been acquired in a blocking way by the above, we can 
+	main::INFOLOG && $log->info("Using Buffered HTTP(S) service for $args->{url}");
+
+	# HTTP headers have now been acquired in a blocking way by the above, we can
 	# now enable fast download of body to a file from which we'll read further data
 	# but the switch of socket handler can only be done within _sysread otherwise
-	# we will timeout when there is a pipeline with a callback 
-	${*$self}{'_fh'} = File::Temp->new( DIR => Slim::Utils::Misc::getTempDir );
+	# we will timeout when there is a pipeline with a callback
+	${*$self}{'_fh'} = File::Temp->new( DIR => Slim::Utils::Misc::getTempDir, SUFFIX => '.buf' );
 	open ${*$self}{'_rfh'}, '<', ${*$self}{'_fh'}->filename;
 	binmode(${*$self}{'_rfh'});
-	
+
 	return $self;
 }
 
@@ -42,10 +43,10 @@ sub close {
 	my $self = shift;
 
 	# clean buffer file and all handlers
-	Slim::Networking::Select::removeRead($self);	
+	Slim::Networking::Select::removeRead($self);
 	${*$self}{'_rfh'}->close if ${*$self}{'_rfh'};
 	delete ${*$self}{'_fh'};
-	
+
 	$self->SUPER::close(@_);
 }
 
@@ -55,17 +56,17 @@ sub close {
 sub _sysread {
 	my $self  = $_[0];
 	my $rfh = ${*$self}{'_rfh'};
-	
+
 	# we are not ready to read body yet, read socket directly
 	return $self->SUPER::_sysread($_[1], $_[2], $_[3]) unless $rfh;
 
 	# first, try to read from buffer file
 	my $readLength = $rfh->read($_[1], $_[2], $_[3]);
 	return $readLength if $readLength;
-	
+
 	# assume that close() will be called for cleanup
 	return 0 if ${*$self}{_done};
-	
+
 	# empty file but not done yet, try to read directly
 	$readLength = $self->SUPER::_sysread($_[1], $_[2], $_[3]);
 
@@ -75,24 +76,24 @@ sub _sysread {
 		Slim::Networking::Select::addRead($self, \&saveStream);
 		return $readLength;
 	}
-		
+
 	# use EINTR because EWOULDBLOCK (although faster) may overwrite our addRead()
 	$! = EINTR;
 	return undef;
 }
 
 sub saveStream {
-    my $self = shift;
-	
+	my $self = shift;
+
 	my $bytes = $self->SUPER::_sysread(my $data, 32768);
 	return unless defined $bytes;
-	
+
 	if ($bytes) {
 		# need to bypass Perl's buffered IO and maje sure read eof is reset
 		syswrite(${*$self}{'_fh'}, $data);
-		${*$self}{'_rfh'}->seek(0, 1);								
+		${*$self}{'_rfh'}->seek(0, 1);
 	} else {
-		Slim::Networking::Select::removeRead($self);	
-		${*$self}{_done} = 1;		
+		Slim::Networking::Select::removeRead($self);
+		${*$self}{_done} = 1;
 	}
-}	
+}

--- a/Slim/Plugin/WiMP/ProtocolHandler.pm
+++ b/Slim/Plugin/WiMP/ProtocolHandler.pm
@@ -6,7 +6,7 @@ package Slim::Plugin::WiMP::ProtocolHandler;
 # version 2.
 
 use strict;
-use base qw(Slim::Player::Protocols::HTTPS);
+use vars qw(@ISA);
 
 use JSON::XS::VersionOneAndTwo;
 use URI::Escape qw(uri_escape_utf8);
@@ -24,6 +24,15 @@ my $log = Slim::Utils::Log->addLogCategory( {
 	'defaultLevel' => 'ERROR',
 	'description'  => 'PLUGIN_WIMP_MODULE_NAME',
 } );
+
+if ($prefs->get('useBufferedHTTP')) {
+	require Slim::Player::Protocols::Buffered;
+	push @ISA, qw(Slim::Player::Protocols::Buffered);
+}
+else {
+	require Slim::Player::Protocols::HTTPS;
+	push @ISA, qw(Slim::Player::Protocols::HTTPS);
+}
 
 # https://tidal.com/browse/track/95570766
 # https://tidal.com/browse/album/95570764
@@ -283,8 +292,8 @@ sub _gotTrack {
 			                                    my $meta = $cache->get('wimp_meta_' . $info->{id});
 			                                    $meta->{bitrate} = sprintf("%.0f" . Slim::Utils::Strings::string('KBPS'), $song->track->bitrate/1000);
 			                                    $cache->set( 'wimp_meta_' . $info->{id}, $meta, 86400 );
-			                                    $params->{successCb}->(); 
-			                               } },						  
+			                                    $params->{successCb}->();
+			                               } },
 			                 $info->{url} ],
 		} );
 	} else {

--- a/Slim/Web/Settings/Server/Performance.pm
+++ b/Slim/Web/Settings/Server/Performance.pm
@@ -22,7 +22,7 @@ sub page {
 }
 
 sub prefs {
-	my @prefs = ( $prefs, qw(dbhighmem disableStatistics serverPriority scannerPriority 
+	my @prefs = ( $prefs, qw(dbhighmem disableStatistics serverPriority scannerPriority useBufferedHTTP
  				precacheArtwork maxPlaylistLength useLocalImageproxy dontTriggerScanOnPrefChange) );
  	push @prefs, qw(autorescan autorescan_stat_interval) if Slim::Utils::OSDetect::getOS->canAutoRescan;
  	return @prefs;

--- a/strings.txt
+++ b/strings.txt
@@ -8414,6 +8414,22 @@ SETUP_ENABLE_STATISTICS
 	SV	Aktivera biblioteksstatistik
 	ZH_CN	启用库存统计
 
+SETUP_BUFFEREDHTTP
+	DE	Online Datenströme zwischenspeichern
+	EN	Cache online streams to disk
+
+SETUP_BUFFEREDHTTP_DESC
+	DE	Logitech Media Server kann HTTP(S) Datenströme mit definierter Länge (Podcasts, einzelne Lieder) im Dateisystem zwischenspeichern. Sie würden wieder gelöscht, sobald der Strom zu Ende gespielt ist. Dies erhöht die Zuverlässigkeit mit einigen Anbietern, kann aber das Dateisystem zusätzlich belasten (z.B. wenn eine SD Karte verwendet wird).
+	EN	Logitech Media Server can cache HTTP(S) streams of defined length (podcasts, single tracks) on disk. The buffer files will be removed again once the stream has been played. This can improve the reliability with some servers. But it also does cause more writing to the file system, which could potentially wear out eg. SD cards.
+
+SETUP_ENABLE_BUFFEREDHTTP
+	DE	HTTP(S) Datenströme zwischenspeichern
+	EN	Cache HTTP(S) streams on disk
+
+SETUP_DISABLE_BUFFEREDHTTP
+	DE	HTTP(S) Datenströme nicht zwischenspeichern
+	EN	Do not cache HTTP(S) streams on disk
+
 SETUP_LONGDATEFORMAT
 	CS	Formát dlouhého data
 	DA	Langt datoformat


### PR DESCRIPTION
Toggling the setting would require a LMS restart for TIDAL to pick up the change.